### PR TITLE
Add descriptions to enums and booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Register-Dokumentation für Xtherma Wärmepumpen.
 | Register | Nummer | Description | Value Range | Wertetyp / Parsing |
 |----------|--------|------------|-------------|--------------------|
 | 0 | 001 | Wärmepumpe ein-/ausgeschaltet | | u16 (bool: 0=Aus, 1=Ein) |
-| 1 | 002 | Betriebsmodus | | u16 (enum: 0=Standby,1=Heizen,2=Kühlen,3=WW,4=Auto) |
-| 2 | 003 | Warmwasser-Sofort-Funktion | | u16 (bool) |
+| 1 | 002 | Betriebsmodus | | u16 (enum: 0=Standby, 1=Heizen, 2=Kühlen, 3=WW, 4=Auto) |
+| 2 | 003 | Warmwasser-Sofort-Funktion | | u16 (bool: 0=Aus, 1=Ein) |
 
 ---
 
@@ -35,7 +35,7 @@ Register-Dokumentation für Xtherma Wärmepumpen.
 
 | Register | Nummer | Description | Value Range | Unit | Wertetyp / Parsing |
 |----------|--------|------------|-------------|------|--------------------|
-| 10 | 310 | Aktiv | | | u16 (bool) |
+| 10 | 310 | Aktiv | | | u16 (bool: 0=Aus, 1=Ein) |
 | 11 | 311 | Außentemperatur P1 | -20..25 | °C | s16 |
 | 12 | 312 | Außentemperatur P2 | -9..25 | °C | s16 |
 | 13 | 315 | Heiztemp P1 | 20..75 | °C | u16 |
@@ -48,7 +48,7 @@ Register-Dokumentation für Xtherma Wärmepumpen.
 
 | Register | Nummer | Description | Value Range | Unit | Wertetyp / Parsing |
 |----------|--------|------------|-------------|------|--------------------|
-| 20 | 350 | Aktiv | | | u16 (bool) |
+| 20 | 350 | Aktiv | | | u16 (bool: 0=Aus, 1=Ein) |
 | 21 | 351 | Außentemperatur P1 | 16..32 | °C | u16 |
 | 22 | 352 | Außentemperatur P2 | 29..45 | °C | u16 |
 | 23 | 355 | Kühltemp P1 | 7..30 | °C | u16 |
@@ -61,7 +61,7 @@ Register-Dokumentation für Xtherma Wärmepumpen.
 
 | Register | Nummer | Description | Value Range | Unit | Wertetyp / Parsing |
 |----------|--------|------------|-------------|------|--------------------|
-| 30 | 410 | Aktiv | | | u16 (bool) |
+| 30 | 410 | Aktiv | | | u16 (bool: 0=Aus, 1=Ein) |
 | 31 | 411 | Außentemperatur P1 | -20..25 | °C | s16 |
 | 32 | 412 | Außentemperatur P2 | -9..25 | °C | s16 |
 | 33 | 415 | Heiztemp P1 | 20..75 | °C | u16 |
@@ -74,7 +74,7 @@ Register-Dokumentation für Xtherma Wärmepumpen.
 
 | Register | Nummer | Description | Value Range | Unit | Wertetyp / Parsing |
 |----------|--------|------------|-------------|------|--------------------|
-| 40 | 450 | Aktiv | | | u16 (bool) |
+| 40 | 450 | Aktiv | | | u16 (bool: 0=Aus, 1=Ein) |
 | 41 | 451 | Außentemperatur P1 | 16..32 | °C | u16 |
 | 42 | 452 | Außentemperatur P2 | 29..45 | °C | u16 |
 | 43 | 455 | Kühltemp P1 | 7..30 | °C | u16 |
@@ -96,11 +96,11 @@ Register-Dokumentation für Xtherma Wärmepumpen.
 
 | Register | Nummer | Description | Value Range | Unit | Wertetyp / Parsing |
 |----------|--------|------------|-------------|------|--------------------|
-| 60 | 815 | SG Ready Modus | | | u16 (enum: 0–3) |
+| 60 | 815 | SG Ready Modus | | | u16 (enum: 0=Kein Eingriff, 1=Normalbetrieb, 2=Sperre, 3=Temperaturen anheben, 4=Anlaufbefehl) |
 | 61 | 811 | ΔT Heizen | 0..30 | K | u16 |
 | 62 | 812 | ΔT WW | 0..30 | K | u16 |
 | 63 | 813 | ΔT Kühlen | 0..30 | K | u16 |
-| 65 | 808 | §14a aktiv | | | u16 (bool) |
+| 65 | 808 | §14a aktiv | | | u16 (bool: 0=Aus, 1=Ein) |
 
 ---
 
@@ -108,7 +108,7 @@ Register-Dokumentation für Xtherma Wärmepumpen.
 
 | Register | Nummer | Description | Value Range | Unit | Wertetyp / Parsing |
 |----------|--------|------------|-------------|------|--------------------|
-| 70 | - | Aktiv | | | u16 (bool) |
+| 70 | - | Aktiv | | | u16 (bool: 0=Aus, 1=Ein) |
 | 71 | - | Überschuss | 0..100000 | W | u16 |
 
 ---
@@ -118,11 +118,11 @@ Register-Dokumentation für Xtherma Wärmepumpen.
 | Register | Key | Description | Value Range | Unit | Wertetyp / Parsing |
 |----------|-----|------------|-------------|------|--------------------|
 | 100 | controller_v | Version | | | u16 |
-| 101 | mode | Modus | | | u16 (enum) |
-| 102 | error | Fehlerstatus | | | u16 (bool inverted) |
-| 103 | 14a | Status | | | u16 (bool) |
-| 104 | sg | SG Status | | | u16 (enum) |
-| 105 | evu | EVU | | | u16 (bool) |
+| 101 | mode | Modus | | | u16 (enum: 0=Standby, 1=Heizbetrieb, 2=Kühlbetrieb, 3=Warmwasser) |
+| 102 | error | Fehlerstatus | | | u16 (bool inverted: 0=Fehler, 1=Kein Fehler) |
+| 103 | 14a | Status | | | u16 (bool: 0=Aus, 1=Ein) |
+| 104 | sg | SG Status | | | u16 (enum: 0=Kein Eingriff, 1=Normalbetrieb, 2=Sperre, 3=Temperaturen anheben, 4=Anlaufbefehl) |
+| 105 | evu | EVU | | | u16 (bool: 0=Aus, 1=Ein) |
 
 ---
 
@@ -159,11 +159,11 @@ Register-Dokumentation für Xtherma Wärmepumpen.
 | Register | Key | Description | Unit | Wertetyp / Parsing |
 |----------|-----|------------|------|--------------------|
 | 130 | v | Volumenstrom | l/min | u16 /10 |
-| 131 | pk | Pumpe | | u16 (bool) |
+| 131 | pk | Pumpe | | u16 (bool: 0=Aus, 1=Ein) |
 | 132 | pkl | Leistung | % | u16 /10 |
-| 133 | pk1 | Kreis 1 | | u16 (bool) |
-| 134 | pk2 | Kreis 2 | | u16 (bool) |
-| 135 | pww | WW Pumpe | | u16 (bool) |
+| 133 | pk1 | Kreis 1 | | u16 (bool: 0=Aus, 1=Ein) |
+| 134 | pk2 | Kreis 2 | | u16 (bool: 0=Aus, 1=Ein) |
+| 135 | pww | WW Pumpe | | u16 (bool: 0=Aus, 1=Ein) |
 | 136 | vf | Verdichter | Hz | u16 |
 | 137 | ld1 | Lüfter 1 | rpm | u16 |
 | 138 | ld2 | Lüfter 2 | rpm | u16 |
@@ -215,4 +215,3 @@ Register-Dokumentation für Xtherma Wärmepumpen.
 | 191 | day_backup6_in_h | Backup 6kW elektrisch | kWh | u16 /100 |
 | 192 | day_backup6_out_hw | Backup WW thermisch | kWh | u16 /100 |
 | 193 | day_backup6_in_hw | Backup WW elektrisch | kWh | u16 /100 |
-

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Register-Dokumentation für Xtherma Wärmepumpen.
 ### Nutzung
 
 - **Rechte:** Block 0-99: Lesen & Schreiben (je alle 1 min; ausgenommen 0, 1, 2, 60, 65 nur alle 30 min), Block 100 - 199 nur lesen
-- **Register-Arten:** Alle Register sind 16Bit Holding Register. 
-- **Port:** 502  
-- **Slave-ID:** 1  
-- **Optimales Pollingintervall:** >60 Sekunden  
+- **Register-Arten:** Alle Register sind 16Bit Holding Register.
+- **Port:** 502
+- **Slave-ID:** 1
+- **Optimales Pollingintervall:** >60 Sekunden
 
 ---
 ### Changelog


### PR DESCRIPTION
### Description

This pull request restores and improves missing descriptions for enums and boolean parameters in the documentation.

During recent changes, several descriptions were (unintentionally?) removed or became incomplete. This PR ensures that all enums and boolean fields are properly documented again, improving clarity and usability for users.

### Changes

- Re-adds missing descriptions for enum values
- Restores documentation for boolean parameters
- Improves consistency, wording and formatting across related sections
- Adds missing parameter for register 60 (4=Anlaufbefehl)
- Resolves #5 

